### PR TITLE
the file ids cannot be resolved correctly using the "full" path

### DIFF
--- a/lib/Operation.php
+++ b/lib/Operation.php
@@ -53,7 +53,7 @@ class Operation implements IOperation {
 
 	public function considerConversion(\OCP\Files\Node $node) {
 		try {
-			$this->workflowEngineManager->setFileInfo($node->getStorage(), $node->getPath());
+			$this->workflowEngineManager->setFileInfo($node->getStorage(), $node->getInternalPath());
 			$matches = $this->workflowEngineManager->getMatchingOperations(Operation::class, false);
 			$originalFileMode = $targetPdfMode = null;
 			foreach($matches as $match) {


### PR DESCRIPTION
Fixes errors like 

```
{PHP} array_merge() expects at least 1 parameter, 0 given at /srv/http/nextcloud/master/apps/workflowengine/lib/Check/FileSystemTags.php#130
{PHP} array_unique() expects parameter 1 to be array, null given at /srv/http/nextcloud/master/apps/workflowengine/lib/Check/FileSystemTags.php#131
{PHP} in_array() expects parameter 2 to be array, null given at /srv/http/nextcloud/master/apps/workflowengine/lib/Check/FileSystemTags.php#84
```

as found by @jospoortvliet 

and thus failing registration of the background job.