### PR TITLE
[stable29] Fix npm audit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4939,10 +4939,11 @@
       "peer": true
     },
     "node_modules/elliptic": {
-      "version": "6.5.4",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
-      "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
+      "version": "6.5.7",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.7.tgz",
+      "integrity": "sha512-ESVCtTwiA+XhY3wyh24QqRGBoP3rEdDUl3EDUUo9tft074fi19IrdpH7hLCMMP3CIj7jb3W96rn8lt/BqIlt5Q==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "bn.js": "^4.11.9",
@@ -11537,10 +11538,11 @@
       }
     },
     "node_modules/vue-template-compiler": {
-      "version": "2.7.13",
-      "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.7.13.tgz",
-      "integrity": "sha512-jYM6TClwDS9YqP48gYrtAtaOhRKkbYmbzE+Q51gX5YDr777n7tNI/IZk4QV4l/PjQPNh/FVa/E92sh/RqKMrog==",
+      "version": "2.7.16",
+      "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.7.16.tgz",
+      "integrity": "sha512-AYbUWAJHLGGQM7+cNTELw+KsOG9nl2CnSv467WobS5Cv9uk3wFcnr1Etsz2sEIHEZvw1U+o9mRlEO6QbZvUPGQ==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "de-indent": "^1.0.2",
@@ -15711,9 +15713,9 @@
       "peer": true
     },
     "elliptic": {
-      "version": "6.5.4",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
-      "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
+      "version": "6.5.7",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.7.tgz",
+      "integrity": "sha512-ESVCtTwiA+XhY3wyh24QqRGBoP3rEdDUl3EDUUo9tft074fi19IrdpH7hLCMMP3CIj7jb3W96rn8lt/BqIlt5Q==",
       "dev": true,
       "peer": true,
       "requires": {
@@ -20693,9 +20695,9 @@
       }
     },
     "vue-template-compiler": {
-      "version": "2.7.13",
-      "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.7.13.tgz",
-      "integrity": "sha512-jYM6TClwDS9YqP48gYrtAtaOhRKkbYmbzE+Q51gX5YDr777n7tNI/IZk4QV4l/PjQPNh/FVa/E92sh/RqKMrog==",
+      "version": "2.7.16",
+      "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.7.16.tgz",
+      "integrity": "sha512-AYbUWAJHLGGQM7+cNTELw+KsOG9nl2CnSv467WobS5Cv9uk3wFcnr1Etsz2sEIHEZvw1U+o9mRlEO6QbZvUPGQ==",
       "dev": true,
       "peer": true,
       "requires": {


### PR DESCRIPTION
# Audit report

This audit fix resolves 7 of the total 9 vulnerabilities found in your project.

## Updated dependencies
* [@nextcloud/axios](#user-content-\@nextcloud\/axios)
* [@nextcloud/vue](#user-content-\@nextcloud\/vue)
* [@vue/component-compiler-utils](#user-content-\@vue\/component-compiler-utils)
* [axios](#user-content-axios)
* [elliptic](#user-content-elliptic)
* [postcss](#user-content-postcss)
* [vue-loader](#user-content-vue-loader)
## Fixed vulnerabilities

### @nextcloud/axios <a href="#user-content-\@nextcloud\/axios" id="\@nextcloud\/axios">#</a>
* Caused by vulnerable dependency:
  * [axios](#user-content-axios)
* Affected versions: <=2.3.0
* Package usage:
  * `node_modules/@nextcloud/axios`

### @nextcloud/vue <a href="#user-content-\@nextcloud\/vue" id="\@nextcloud\/vue">#</a>
* Caused by vulnerable dependency:
  * [@nextcloud/axios](#user-content-\@nextcloud\/axios)
* Affected versions: <=6.0.0-beta.8
* Package usage:
  * `node_modules/@nextcloud/vue`

### @vue/component-compiler-utils <a href="#user-content-\@vue\/component-compiler-utils" id="\@vue\/component-compiler-utils">#</a>
* Caused by vulnerable dependency:
  * [postcss](#user-content-postcss)
* Affected versions: *
* Package usage:
  * `node_modules/@vue/component-compiler-utils`

### axios <a href="#user-content-axios" id="axios">#</a>
* Axios Cross-Site Request Forgery Vulnerability
* Severity: **moderate** (CVSS 6.5)
* Reference: [https://github.com/advisories/GHSA-wf5p-g6vw-rhxx](https://github.com/advisories/GHSA-wf5p-g6vw-rhxx)
* Affected versions: 0.8.1 - 0.27.2
* Package usage:
  * `node_modules/axios`

### elliptic <a href="#user-content-elliptic" id="elliptic">#</a>
* Elliptic's EDDSA missing signature length check
* Severity: **low** (CVSS 5.3)
* Reference: [https://github.com/advisories/GHSA-f7q4-pwc6-w24p](https://github.com/advisories/GHSA-f7q4-pwc6-w24p)
* Affected versions: 2.0.0 - 6.5.6
* Package usage:
  * `node_modules/elliptic`

### postcss <a href="#user-content-postcss" id="postcss">#</a>
* PostCSS line return parsing error
* Severity: **moderate** (CVSS 5.3)
* Reference: [https://github.com/advisories/GHSA-7fh5-64p2-3v2j](https://github.com/advisories/GHSA-7fh5-64p2-3v2j)
* Affected versions: <8.4.31
* Package usage:
  * `node_modules/@vue/component-compiler-utils/node_modules/postcss`

### vue-loader <a href="#user-content-vue-loader" id="vue-loader">#</a>
* Caused by vulnerable dependency:
  * [@vue/component-compiler-utils](#user-content-\@vue\/component-compiler-utils)
* Affected versions: 15.0.0-beta.1 - 15.11.1
* Package usage:
  * `node_modules/vue-loader`